### PR TITLE
Add a setting to hide the icon of damageable items if their damage is less than the specified threshold

### DIFF
--- a/src/main/java/de/guntram/mcmod/durabilityviewer/handler/ConfigurationHandler.java
+++ b/src/main/java/de/guntram/mcmod/durabilityviewer/handler/ConfigurationHandler.java
@@ -29,6 +29,7 @@ public class ConfigurationHandler implements ModConfigurationHandler
     private int minDurability = 100;
     private boolean showPlayerServerName;
     private int showDamageOverPercent;
+    private int hideDamageOverPercent;
     private boolean armorAroundHotbar;
     private boolean showChestIcon;
     private boolean showAllTrinkets;
@@ -99,6 +100,7 @@ public class ConfigurationHandler implements ModConfigurationHandler
         minDurability = config.getInt("durabilityviewer.config.mindurability", Configuration.CATEGORY_CLIENT, minDurability, 1, 1500, "durabilityviewer.config.tt.mindurability");
         showPlayerServerName = config.getBoolean("durabilityviewer.config.setwindowtitle", Configuration.CATEGORY_CLIENT, true, "durabilityviewer.config.tt.setwindowtitle");
         showDamageOverPercent = config.getInt("durabilityviewer.config.showdamagepercent", Configuration.CATEGORY_CLIENT, 80, 0, 100, "durabilityviewer.config.tt.showdamagepercent");
+        hideDamageOverPercent = config.getInt("durabilityviewer.config.hidedamagepercent", Configuration.CATEGORY_CLIENT, 100, 0, 100, "durabilityviewer.config.tt.hidedamagepercent");
         showChestIcon = config.getBoolean("durabilityviewer.config.showfreeslots", Configuration.CATEGORY_CLIENT, true, "durabilityviewer.config.tt.showfreeslots");
         showAllTrinkets = config.getBoolean("durabilityviewer.config.showalltrinkets", Configuration.CATEGORY_CLIENT, true, "durabilityviewer.config.tt.showalltrinkets");
         showPercentValues = config.getBoolean("durabilityviewer.config.percentvalues", Configuration.CATEGORY_CLIENT, false, "durabilityviewer.config.tt.percentvalues");
@@ -140,6 +142,10 @@ public class ConfigurationHandler implements ModConfigurationHandler
     
     public static int showDamageOverPercent() {
         return getInstance().showDamageOverPercent;
+    }
+
+    public static int hideDamageOverPercent() {
+        return getInstance().hideDamageOverPercent;
     }
     
     public static boolean getArmorAroundHotbar() {

--- a/src/main/java/de/guntram/mcmod/durabilityviewer/itemindicator/ItemDamageIndicator.java
+++ b/src/main/java/de/guntram/mcmod/durabilityviewer/itemindicator/ItemDamageIndicator.java
@@ -29,7 +29,7 @@ public class ItemDamageIndicator implements ItemIndicator {
         int cur=max-dam;
 
         int shown;
-        if (cur > max*ConfigurationHandler.showDamageOverPercent()/100) {
+        if (cur > max * ConfigurationHandler.showDamageOverPercent()/100) {
             shown=-dam;
         } else {
             shown=cur;
@@ -59,7 +59,7 @@ public class ItemDamageIndicator implements ItemIndicator {
     
     @Override
     public boolean isEmpty() {
-        return stack.isEmpty();
+        return stack.isEmpty() || (stack.getDamage() > stack.getMaxDamage() * ConfigurationHandler.hideDamageOverPercent()/100);
     }
 
     @Override

--- a/src/main/java/de/guntram/mcmod/durabilityviewer/itemindicator/ItemDamageIndicator.java
+++ b/src/main/java/de/guntram/mcmod/durabilityviewer/itemindicator/ItemDamageIndicator.java
@@ -59,7 +59,7 @@ public class ItemDamageIndicator implements ItemIndicator {
     
     @Override
     public boolean isEmpty() {
-        return stack.isEmpty() || (stack.getDamage() > stack.getMaxDamage() * ConfigurationHandler.hideDamageOverPercent()/100);
+        return stack.isEmpty() || (stack.getMaxDamage() - stack.getDamage() > stack.getMaxDamage() * ConfigurationHandler.hideDamageOverPercent()/100);
     }
 
     @Override

--- a/src/main/resources/assets/durabilityviewer/lang/en_us.json
+++ b/src/main/resources/assets/durabilityviewer/lang/en_us.json
@@ -11,6 +11,7 @@
     "durabilityviewer.config.mindurability": "Sound below durability",
     "durabilityviewer.config.setwindowtitle": "Set window title",
     "durabilityviewer.config.showdamagepercent": "Percent to show damage",
+    "durabilityviewer.config.hidedamagepercent": "Percent to hide icons",
     "durabilityviewer.config.showfreeslots": "Show free inventory slots",
     "durabilityviewer.config.showalltrinkets": "Show all trinkets",
     "durabilityviewer.config.percentvalues": "Percentages",


### PR DESCRIPTION
I play with AutoHud which hides even things like Health and Hunger most of the time; thus, I thought it was kind of strange to have the durability of my armor always showing, even when I shouldn't be concerned with it. So I added this, with a setting of 100 by default to always show tools (current behavior) but users can configure it to whatever they like, for example I am using 50%.