### PR TITLE
Add configuration option to toggle the red overlay associated with visual warning mode

### DIFF
--- a/src/main/java/de/guntram/mcmod/durabilityviewer/client/gui/GuiItemDurability.java
+++ b/src/main/java/de/guntram/mcmod/durabilityviewer/client/gui/GuiItemDurability.java
@@ -318,13 +318,16 @@ public class GuiItemDurability
     
     private void renderItemBreakingOverlay(DrawContext context, ItemStack itemStack, long timeDelta) {
         Window mainWindow = MinecraftClient.getInstance().getWindow();
-        float alpha = 1.0f-((float)timeDelta/1000.0f);
         float xWarn = mainWindow.getScaledWidth()/2;
         float yWarn = mainWindow.getScaledHeight()/2;
         float scale = 5.0f;
-        
-        context.fill(0, 0, mainWindow.getScaledWidth(), mainWindow.getScaledHeight(),
-                0xff0000+ ((int)(alpha*128)<<24));
+
+        if (ConfigurationHandler.showWarnOverlay()) {
+            float alpha = 1.0f-((float)timeDelta/1000.0f);
+            context.fill(0, 0, mainWindow.getScaledWidth(), mainWindow.getScaledHeight(),
+                0xff0000 + ((int) (alpha * 128) << 24)
+            );
+        }
         
         MatrixStack stack = RenderSystem.getModelViewStack();
         stack.push();

--- a/src/main/java/de/guntram/mcmod/durabilityviewer/handler/ConfigurationHandler.java
+++ b/src/main/java/de/guntram/mcmod/durabilityviewer/handler/ConfigurationHandler.java
@@ -35,6 +35,7 @@ public class ConfigurationHandler implements ModConfigurationHandler
     private boolean showAllTrinkets;
     private boolean showPercentValues;
     private int warnMode;
+    private boolean showWarnOverlay;
 
     public static ConfigurationHandler getInstance() {
         if (instance==null)
@@ -105,6 +106,7 @@ public class ConfigurationHandler implements ModConfigurationHandler
         showAllTrinkets = config.getBoolean("durabilityviewer.config.showalltrinkets", Configuration.CATEGORY_CLIENT, true, "durabilityviewer.config.tt.showalltrinkets");
         showPercentValues = config.getBoolean("durabilityviewer.config.percentvalues", Configuration.CATEGORY_CLIENT, false, "durabilityviewer.config.tt.percentvalues");
         warnMode = config.getSelection("durabilityviewer.config.warnmode", Configuration.CATEGORY_CLIENT, 1, warnModes, "durabilityviewer.config.tt.warnmode");
+        showWarnOverlay = config.getBoolean("durabilityviewer.config.showwarnoverlay", Configuration.CATEGORY_CLIENT, true, "durabilityviewer.config.tt.showwarnoverlay");
 
         tooltipColor=Formatting.byColorIndex(color);
         if (config.hasChanged())
@@ -159,4 +161,9 @@ public class ConfigurationHandler implements ModConfigurationHandler
     public static boolean getShowPercentValues() { return getInstance().showPercentValues; }
     
     public static int getWarnMode() { return getInstance().warnMode; }
+
+    public static boolean showWarnOverlay() {
+        return getInstance().showWarnOverlay;
+    }
+
 }


### PR DESCRIPTION
The red overlay that flashes on the entire screen when the visual warning appears might prove to be excessively obtrusive.

Personally, when using the visual warning and deliberately using a tool until it breaks, my eyes start to hurt from the fast red flashes.

I have added a configuration option to turn it off, so that only the item is displayed in visual mode, without the red overlay.
By default, the configuration option is turned on, to preserve backwards compatibility.

On a different note, I want to kindly inquire: are you building the project in its current state?
After forking and cloning the latest state of the branch `fabric_1_20` at the time of writing, I found it incredibly inconvenient to build the project:
- I had to add a `gradle.properties` file to specify `org.gradle.jvmargs=-Xmx1G`, otherwise I was met with an out-of-memory error when gradle performed the remapping, within the project's setup procedure
- I had to change the loom version from `'1.3-SNAPSHOT'` to `'1.5-SNAPSHOT'` to allow some remap operations
- I had to update TechReborn from `1.16:3.4.5+build.95` to `1.20:5.10.3`, otherwise some mixins were not properly injected
  - Along with this, instead of `team.reborn.energy.EnergyHolder` use `team.reborn.energy.api.EnergyStorage`, and instead of `EnergyHolder.getMaxStoredPower()` use `EnergyStorage.getCapacity()` (although I haven't tested this at all, I just wanted to be able to build the project, those NBT operations might need some hammers now)
- I had to update Mod Menu just to be able to see the menu screen (otherwise it crashed), yet even after I updated it to `9.0.0`, game crashes upon trying to open this mod's page via Mod Menu. But at least I can load into a world

So I decided to just commit the changes related to the configuration option, hoping you will add them and then create a new release with them in it, however you may be building it, for I am unsure as to how you are building it in its current state...

Do you have all these changes as uncommitted changes?